### PR TITLE
Allow upserting single document

### DIFF
--- a/tests/asyncio/test_index.py
+++ b/tests/asyncio/test_index.py
@@ -56,6 +56,42 @@ async def test_upsert_async(async_index: AsyncIndex) -> None:
 
 
 @pytest.mark.asyncio
+async def test_upsert_single_async(async_index: AsyncIndex) -> None:
+    await async_index.upsert(
+        ("id-0", {"data": 0}),
+    )
+
+    await async_index.upsert(
+        {"id": "id-1", "content": {"data": 1}, "metadata": {"key": "value-1"}},
+    )
+
+    await async_index.upsert(
+        Document(id="id-2", content={"data": 2}),
+    )
+
+    documents = await async_index.fetch(
+        ids=["id-0", "id-1", "id-2"],
+    )
+
+    assert len(documents) == 3
+
+    assert documents[0] is not None
+    assert documents[0].id == "id-0"
+    assert documents[0].content == {"data": 0}
+    assert documents[0].metadata is None
+
+    assert documents[1] is not None
+    assert documents[1].id == "id-1"
+    assert documents[1].content == {"data": 1}
+    assert documents[1].metadata == {"key": "value-1"}
+
+    assert documents[2] is not None
+    assert documents[2].id == "id-2"
+    assert documents[2].content == {"data": 2}
+    assert documents[2].metadata is None
+
+
+@pytest.mark.asyncio
 async def test_upsert_invalid_tuple_or_dict_async(async_index: AsyncIndex) -> None:
     with pytest.raises(Exception):
         await async_index.upsert(documents=[("id",)])

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -54,6 +54,41 @@ def test_upsert(index: Index) -> None:
     assert documents[5].metadata == {"key": "value-5"}
 
 
+def test_upsert_single(index: Index) -> None:
+    index.upsert(
+        ("id-0", {"data": 0}),
+    )
+
+    index.upsert(
+        {"id": "id-1", "content": {"data": 1}, "metadata": {"key": "value-1"}},
+    )
+
+    index.upsert(
+        Document(id="id-2", content={"data": 2}),
+    )
+
+    documents = index.fetch(
+        ids=["id-0", "id-1", "id-2"],
+    )
+
+    assert len(documents) == 3
+
+    assert documents[0] is not None
+    assert documents[0].id == "id-0"
+    assert documents[0].content == {"data": 0}
+    assert documents[0].metadata is None
+
+    assert documents[1] is not None
+    assert documents[1].id == "id-1"
+    assert documents[1].content == {"data": 1}
+    assert documents[1].metadata == {"key": "value-1"}
+
+    assert documents[2] is not None
+    assert documents[2].id == "id-2"
+    assert documents[2].content == {"data": 2}
+    assert documents[2].metadata is None
+
+
 def test_upsert_invalid_tuple_or_dict(index: Index) -> None:
     with pytest.raises(Exception):
         index.upsert(documents=[("id",)])

--- a/upstash_search/asyncio/index.py
+++ b/upstash_search/asyncio/index.py
@@ -17,6 +17,7 @@ from upstash_search.types import (
     parse_document,
     parse_deleted,
     parse_range_documents,
+    UpsertDocumentT,
 )
 from upstash_search.utils import documents_to_payload
 
@@ -39,9 +40,7 @@ class AsyncIndex:
 
     async def upsert(
         self,
-        documents: t.Sequence[
-            t.Union[t.Dict[t.Any, t.Any], t.Tuple[t.Any, ...], Document]
-        ],
+        documents: t.Union[UpsertDocumentT, t.List[UpsertDocumentT]],
     ) -> None:
         """
         Upserts(updates or inserts) documents.
@@ -53,6 +52,8 @@ class AsyncIndex:
 
         :param documents: Documents to upsert.
         """
+        if not isinstance(documents, list):
+            documents = [documents]
 
         payload = documents_to_payload(documents)
 

--- a/upstash_search/index.py
+++ b/upstash_search/index.py
@@ -17,6 +17,7 @@ from upstash_search.types import (
     parse_document,
     parse_deleted,
     parse_range_documents,
+    UpsertDocumentT,
 )
 from upstash_search.utils import documents_to_payload
 
@@ -39,9 +40,7 @@ class Index:
 
     def upsert(
         self,
-        documents: t.Sequence[
-            t.Union[t.Dict[t.Any, t.Any], t.Tuple[t.Any, ...], Document]
-        ],
+        documents: t.Union[UpsertDocumentT, t.List[UpsertDocumentT]],
     ) -> None:
         """
         Upserts(updates or inserts) documents.
@@ -53,6 +52,8 @@ class Index:
 
         :param documents: Documents to upsert.
         """
+        if not isinstance(documents, list):
+            documents = [documents]
 
         payload = documents_to_payload(documents)
 

--- a/upstash_search/types.py
+++ b/upstash_search/types.py
@@ -17,6 +17,13 @@ def parse_document(result: t.Dict[t.Any, t.Any]) -> Document:
     )
 
 
+UpsertDocumentT = t.Union[
+    Document,
+    t.Dict[str, t.Any],
+    t.Tuple[t.Any, ...],
+]
+
+
 @dataclasses.dataclass
 class DocumentScore:
     id: str


### PR DESCRIPTION
Similar to JS SDK, we now allow you to upsert a single document without wrapping it into a list.