### PR TITLE
Use latest version of poetry in workflows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,10 +13,10 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install Poetry
-        run: curl -sSL https://install.python-poetry.org | python3 - --version 1.8.4
+        run: curl -sSL https://install.python-poetry.org | python3 -
 
       - name: Build and publish
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,14 +20,14 @@ jobs:
           python-version: 3.9
 
       - name: Install Poetry
-        run: curl -sSL https://install.python-poetry.org | python3 - --version 1.8.4
+        run: curl -sSL https://install.python-poetry.org | python3 -
 
       - name: Set up Poetry environment
         run: poetry install --no-root
 
       - name: Run mypy
         run: |
-          poetry run mypy --show-error-codes --install-types --non-interactive --show-error-codes --strict .
+          poetry run mypy --show-error-codes --show-error-codes --strict .
 
       - name: Run ruff
         run: |


### PR DESCRIPTION
Since we do not support python 3.8, we can use
the latest version of poetry in workflows.